### PR TITLE
Fix duplicated global style blocks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import { Main } from '@aragon/ui'
 import App from './App'
 import initializeSentry from './sentry'
 
@@ -11,8 +12,13 @@ if (module.hot) {
 }
 
 ReactDOM.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
+  // Global styles must be applied outside of <React.StrictMode/> to avoid duplicates being rendered inside head.
+  // As <Main/> provides us with some globals we need to ensure it sits outside.
+  // See – https://github.com/styled-components/styled-components/issues/3008
+  <Main layout={false} scrollView={false}>
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  </Main>,
   document.getElementById('root')
 )


### PR DESCRIPTION
The upgrade to styled-components v5 was causing duplicate global style blocks to be rendered in the head. They seemed to originate from `<Main/>` in aragon/ui. For now I think it's best to pin it to v4.

@delfipolito this should resolve the issue we discussed with HMR reloads.