### PR TITLE
Disable jsx-key lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
     'react/prop-types': 'warn',
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'error',
+    'react/jsx-key': 0,
     'import/no-unresolved': [
       'error',
       { ignore: ['^react(-dom)?$', '^styled-components$'] },


### PR DESCRIPTION
We often statically store and pass components via arrays for tuple like syntax etc, so disabling this [jsx-key rule](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md) should cut out noise and keep us consistent with other code.