### PR TITLE
Update useDisputableVote on id change, react api loading statuses

### DIFF
--- a/src/components/Proposals/ProposalDetail.js
+++ b/src/components/Proposals/ProposalDetail.js
@@ -60,7 +60,8 @@ function getAttributes(status, theme) {
 
 function ProposalDetail({ match }) {
   const { id: proposalId } = match.params
-  const [vote, { loading }] = useDisputableVote(proposalId)
+
+  const [vote, { loading: voteLoading }] = useDisputableVote(proposalId)
   const theme = useTheme()
 
   const { layoutName } = useLayout()
@@ -70,7 +71,7 @@ function ProposalDetail({ match }) {
     history.push(`/proposals`)
   }, [history])
 
-  if (loading) {
+  if (voteLoading) {
     return <div>Loading...</div>
   }
 

--- a/src/hooks/useAgreementDetails.js
+++ b/src/hooks/useAgreementDetails.js
@@ -15,8 +15,12 @@ const useAgreementHook = createAppHook(connectAgreement, connecterConfig)
 
 export function useAgreementDetails() {
   const { agreementApp } = useOrgApps()
-  const [agreement] = useAgreementHook(agreementApp, (app) => app)
+  const [agreement, { loading: agreementAppLoading }] = useAgreementHook(
+    agreementApp,
+    (app) => app
+  )
   const [agreementDetails, setAgreementDetails] = useState(null)
+  const [agreementDetailsLoading, setAgreementDetailsLoading] = useState(true)
 
   useEffect(() => {
     let cancelled = false
@@ -63,20 +67,21 @@ export function useAgreementDetails() {
 
         if (!cancelled) {
           setAgreementDetails(details)
+          setAgreementDetailsLoading(false)
         }
       } catch (error) {
         console.error(error)
       }
     }
 
-    if (agreement && !agreementDetails) {
+    if (!agreementAppLoading) {
       getAgreementDetails()
     }
 
     return () => {
       cancelled = true
     }
-  }, [agreement, agreementDetails])
+  }, [agreement, agreementAppLoading])
 
-  return agreementDetails
+  return [agreementDetails, { loading: agreementDetailsLoading }]
 }

--- a/src/hooks/useDisputableVotes.js
+++ b/src/hooks/useDisputableVotes.js
@@ -24,7 +24,7 @@ export function useDisputableVotes() {
     console.error(error)
   }
 
-  return [votes, { loading, error }]
+  return [votes, { loading }]
 }
 
 export function useDisputableVote(proposalId) {

--- a/src/hooks/useDisputableVotes.js
+++ b/src/hooks/useDisputableVotes.js
@@ -15,52 +15,41 @@ const useDisputableVotingHook = createAppHook(connectVoting, connecterConfig)
 
 export function useDisputableVotes() {
   const { disputableVotingApp } = useOrgApps()
-  const [disputableVoting] = useDisputableVotingHook(
-    disputableVotingApp,
-    (app) => app
-  )
-  const [disputableVotes, setDisputableVotes] = useState(null)
+  const [
+    votes,
+    { loading, error },
+  ] = useDisputableVotingHook(disputableVotingApp, (app) => app.votes())
 
-  useEffect(() => {
-    let cancelled = false
+  if (error) {
+    console.error(error)
+  }
 
-    async function getVotes() {
-      try {
-        const votes = await disputableVoting.votes()
-
-        if (!cancelled) {
-          setDisputableVotes(votes)
-        }
-      } catch (error) {
-        console.error(error)
-      }
-    }
-
-    if (disputableVoting && !disputableVotes) {
-      getVotes()
-    }
-
-    return () => {
-      cancelled = true
-    }
-  }, [disputableVotes, disputableVoting])
-
-  return disputableVotes
+  return [votes, { loading, error }]
 }
 
 export function useDisputableVote(proposalId) {
   const { disputableVotingApp } = useOrgApps()
-  const [loading, setLoading] = useState(true)
+  const [extendedVoteLoading, setExtendedVoteLoading] = useState(true)
   const [extendedVote, setExtendedVote] = useState(null)
 
-  const [vote] = useDisputableVotingHook(disputableVotingApp, (app) => {
-    return app.vote(`${disputableVotingApp.address}-vote-${proposalId}`)
-  })
+  const [vote, { loading: voteLoading }] = useDisputableVotingHook(
+    disputableVotingApp,
+    (app) => {
+      return app.vote(`${disputableVotingApp.address}-vote-${proposalId}`)
+    },
+
+    // Refresh vote on id change
+    [proposalId]
+  )
 
   useEffect(() => {
     let cancelled = false
 
     async function getExtendedVote() {
+      if (!cancelled) {
+        setExtendedVoteLoading(true)
+      }
+
       try {
         const [collateral, settings] = await Promise.all([
           vote.collateralRequirement(),
@@ -87,21 +76,21 @@ export function useDisputableVote(proposalId) {
         }
         if (!cancelled) {
           setExtendedVote(extendedVote)
-          setLoading(false)
+          setExtendedVoteLoading(false)
         }
       } catch (error) {
         console.error(error)
       }
     }
 
-    if (vote && !extendedVote) {
+    if (!voteLoading) {
       getExtendedVote()
     }
 
     return () => {
       cancelled = true
     }
-  }, [vote, extendedVote])
+  }, [vote, voteLoading])
 
-  return [extendedVote, { loading: loading }]
+  return [extendedVote, { loading: extendedVoteLoading }]
 }

--- a/src/providers/AppData.js
+++ b/src/providers/AppData.js
@@ -10,10 +10,16 @@ const AppDataContext = React.createContext({
 })
 
 function AppDataProvider({ children }) {
-  const agreementDetails = useAgreementDetails()
-  const disputableVotes = useDisputableVotes()
+  const [
+    agreementDetails,
+    { loading: agreementDetailsLoading },
+  ] = useAgreementDetails()
+  const [
+    disputableVotes,
+    { loading: disputableVotesLoading },
+  ] = useDisputableVotes()
 
-  const dataLoading = !agreementDetails || !disputableVotes
+  const dataLoading = agreementDetailsLoading || disputableVotesLoading
 
   const appDataState = useMemo(
     () => ({

--- a/src/providers/OrgApps.js
+++ b/src/providers/OrgApps.js
@@ -14,22 +14,20 @@ function getAppByName(apps, appName) {
 }
 
 function OrgAppsProvider({ children }) {
-  const [apps] = useApps()
+  const [apps, { loading }] = useApps()
 
   // Avoid additional overhead by finding within existing app list
   const agreementApp = getAppByName(apps, 'agreement')
   const disputableVotingApp = getAppByName(apps, 'disputable-voting')
-
-  const appsLoading = !apps
 
   const OrgAppState = useMemo(
     () => ({
       apps,
       agreementApp,
       disputableVotingApp,
-      appsLoading,
+      appsLoading: loading,
     }),
-    [apps, agreementApp, disputableVotingApp, appsLoading]
+    [apps, agreementApp, disputableVotingApp, loading]
   )
 
   return (


### PR DESCRIPTION
This PR makes use of the loading statuses from `connect-react` to inform us when data is ready to be used. It also uses the new dependency array to more elegantly update current vote when `proposalId` changes in `useDisputableVote`.