### PR TITLE
Performance: Progressively render descriptions

### DIFF
--- a/src/components/Loading/LoadingSkeleton.js
+++ b/src/components/Loading/LoadingSkeleton.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { useTheme, GU, RADIUS } from '@aragon/ui'
+
+function LoadingSkeleton({ ...props }) {
+  const theme = useTheme()
+
+  return (
+    <div
+      css={`
+        border-radius: ${RADIUS}px;
+        background-color: ${theme.disabled};
+
+        width: 100%;
+        height: ${2 * GU}px;
+
+        &:not(:last-child) {
+          margin-bottom: ${1 * GU}px;
+        }
+      `}
+      {...props}
+    />
+  )
+}
+
+export default LoadingSkeleton

--- a/src/components/Proposals/Description.js
+++ b/src/components/Proposals/Description.js
@@ -1,6 +1,6 @@
 import React from 'react'
+import { PropTypes } from 'prop-types'
 import { GU, IdentityBadge, useTheme } from '@aragon/ui'
-import { propTypes } from '@aragon/ui/dist/index-46d0e707'
 
 function Description({ path }) {
   return (
@@ -108,7 +108,7 @@ function DescriptionStep({ step }) {
 /* eslint-enable react/prop-types */
 
 Description.propTypes = {
-  path: propTypes.array,
+  path: PropTypes.array,
 }
 
 export default Description

--- a/src/components/Proposals/Description.js
+++ b/src/components/Proposals/Description.js
@@ -1,9 +1,11 @@
 import React from 'react'
 import { GU, IdentityBadge, useTheme } from '@aragon/ui'
+import { propTypes } from '@aragon/ui/dist/index-46d0e707'
 
-/* eslint-disable react/prop-types */
-function Description({ path }) {
-  return (
+function Description({ path, loading }) {
+  return loading ? (
+    'Loading...'
+  ) : (
     <span
       css={`
         // overflow-wrap:anywhere and hyphens:auto are not supported yet by
@@ -21,6 +23,7 @@ function Description({ path }) {
   )
 }
 
+/* eslint-disable react/prop-types */
 function DescriptionStep({ step }) {
   const theme = useTheme()
 
@@ -61,7 +64,8 @@ function DescriptionStep({ step }) {
       </span>
     )
   }
-  description.push(<br key={description.lenth + 1} />)
+
+  description.push(<br key={description.length + 1} />)
 
   const childrenDescriptions = (step.children || []).map((child, index) => {
     return <DescriptionStep step={child} key={index} />
@@ -103,6 +107,11 @@ function DescriptionStep({ step }) {
     </>
   )
 }
-/* eslint-disable react/prop-types */
+/* eslint-enable react/prop-types */
+
+Description.propTypes = {
+  path: propTypes.array,
+  loading: propTypes.bool,
+}
 
 export default Description

--- a/src/components/Proposals/Description.js
+++ b/src/components/Proposals/Description.js
@@ -2,10 +2,8 @@ import React from 'react'
 import { GU, IdentityBadge, useTheme } from '@aragon/ui'
 import { propTypes } from '@aragon/ui/dist/index-46d0e707'
 
-function Description({ path, loading }) {
-  return loading ? (
-    'Loading...'
-  ) : (
+function Description({ path }) {
+  return (
     <span
       css={`
         // overflow-wrap:anywhere and hyphens:auto are not supported yet by
@@ -111,7 +109,6 @@ function DescriptionStep({ step }) {
 
 Description.propTypes = {
   path: propTypes.array,
-  loading: propTypes.bool,
 }
 
 export default Description

--- a/src/components/Proposals/ProposalCard.js
+++ b/src/components/Proposals/ProposalCard.js
@@ -10,8 +10,9 @@ import {
 import ProposalOption from './ProposalOption'
 import DisputableStatusLabel from './DisputableStatusLabel'
 import Description from './Description'
-import { useDescribeVote } from '../../hooks/useDescribeVote'
 import { getAppPresentation } from '../../utils/app-utils'
+import LoadingSkeleton from '../Loading/LoadingSkeleton'
+import { useDescribeVote } from '../../hooks/useDescribeVote'
 import { useOrgApps } from '../../providers/OrgApps'
 
 function getAttributes(status, theme) {
@@ -104,11 +105,17 @@ function ProposalCard({ vote, onProposalClick }) {
           overflow: hidden;
         `}
       >
-        <strong css="font-weight: bold">#{voteId}: </strong>
         {emptyScript ? (
-          context || 'No description provided'
+          <>
+            <strong css="font-weight: bold">#{voteId}: </strong>
+            {context || 'No description provided'}
+          </>
         ) : (
-          <Description path={description} loading={descriptionLoading} />
+          <DescriptionWithSkeleton
+            description={description}
+            loading={descriptionLoading}
+            voteNumber={voteId}
+          />
         )}
       </p>
 
@@ -164,7 +171,14 @@ function DefaultAppBadge() {
 /* eslint-disable react/prop-types */
 function AppBadgeWithSkeleton({ targetApp, loading }) {
   if (loading) {
-    return 'AppBadge is loading'
+    return (
+      <LoadingSkeleton
+        css={`
+          height: ${3 * GU}px;
+          width: ${12 * GU}px;
+        `}
+      />
+    )
   }
 
   const { address, name, icon } = targetApp
@@ -176,6 +190,37 @@ function AppBadgeWithSkeleton({ targetApp, loading }) {
       iconSrc={icon}
       badgeOnly
     />
+  )
+}
+
+function DescriptionWithSkeleton({ description, voteNumber, loading }) {
+  if (loading) {
+    return (
+      <>
+        <LoadingSkeleton
+          css={`
+            width: 95%;
+          `}
+        />
+        <LoadingSkeleton
+          css={`
+            width: 70%;
+          `}
+        />
+        <LoadingSkeleton
+          css={`
+            width: 35%;
+          `}
+        />
+      </>
+    )
+  }
+
+  return (
+    <>
+      <strong css="font-weight: bold">#{voteNumber}: </strong>{' '}
+      <Description path={description} />
+    </>
   )
 }
 /* eslint-enable react/prop-types */

--- a/src/components/Proposals/ProposalDetails/ProposalDetails.js
+++ b/src/components/Proposals/ProposalDetails/ProposalDetails.js
@@ -33,6 +33,7 @@ import Description from '../Description'
 import { addressesEqual } from '../../../lib/web3-utils'
 import { getIpfsUrlFromUri } from '../../../lib/ipfs-utils'
 import { useDescribeVote } from '../../../hooks/useDescribeVote'
+import LoadingSkeleton from '../../Loading/LoadingSkeleton'
 
 function getAttributes(status, theme) {
   const attributes = {
@@ -162,7 +163,10 @@ function Details({ vote, status }) {
       ) : (
         <div>
           <InfoField label="Description">
-            <Description path={description} loading={descriptionLoading} />
+            <DescriptionWithSkeleton
+              description={description}
+              loading={descriptionLoading}
+            />
           </InfoField>
 
           <InfoField
@@ -236,6 +240,34 @@ function Details({ vote, status }) {
       </InfoField>
     </div>
   )
+}
+
+function DescriptionWithSkeleton({ description, loading }) {
+  const theme = useTheme()
+  if (loading) {
+    return (
+      <>
+        <LoadingSkeleton
+          theme={theme}
+          css={`
+            width: 95%;
+          `}
+        />
+        <LoadingSkeleton
+          css={`
+            width: 70%;
+          `}
+        />
+        <LoadingSkeleton
+          css={`
+            width: 35%;
+          `}
+        />
+      </>
+    )
+  }
+
+  return <Description path={description} />
 }
 
 function SummaryInfo({ vote, disabledProgressBars }) {

--- a/src/components/Proposals/ProposalDetails/ProposalDetails.js
+++ b/src/components/Proposals/ProposalDetails/ProposalDetails.js
@@ -243,12 +243,10 @@ function Details({ vote, status }) {
 }
 
 function DescriptionWithSkeleton({ description, loading }) {
-  const theme = useTheme()
   if (loading) {
     return (
       <>
         <LoadingSkeleton
-          theme={theme}
           css={`
             width: 95%;
           `}

--- a/src/components/Proposals/ProposalDetails/ProposalDetails.js
+++ b/src/components/Proposals/ProposalDetails/ProposalDetails.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import {
   Box,
@@ -32,6 +32,7 @@ import FeedbackModule from './FeedbackModule'
 import Description from '../Description'
 import { addressesEqual } from '../../../lib/web3-utils'
 import { getIpfsUrlFromUri } from '../../../lib/ipfs-utils'
+import { useDescribeVote } from '../../../hooks/useDescribeVote'
 
 function getAttributes(status, theme) {
   const attributes = {
@@ -130,14 +131,21 @@ function ProposalDetail({ vote }) {
 
 /* eslint-disable react/prop-types */
 function Details({ vote, status }) {
-  const { context, creator, collateral, token, description } = vote
+  const { context, creator, collateral, token, script } = vote
   const { layoutName } = useLayout()
+  const {
+    description,
+    emptyScript,
+    loading: descriptionLoading,
+  } = useDescribeVote(script, vote.id)
+
   const compactMode = layoutName === 'small'
 
-  let ipfsJustification = null
-  if (context.startsWith('ipfs')) {
-    ipfsJustification = context
-  }
+  const justificationUrl = useMemo(
+    () => (context.startsWith('ipfs') ? getIpfsUrlFromUri(context) : null),
+    [context]
+  )
+
   return (
     <div
       css={`
@@ -147,20 +155,25 @@ function Details({ vote, status }) {
         grid-gap: ${3 * GU}px;
       `}
     >
-      {Array.isArray(description) ? (
+      {emptyScript ? (
+        <InfoField label="Description">
+          <p>{context}</p>
+        </InfoField>
+      ) : (
         <div>
           <InfoField label="Description">
-            <Description path={description} />
+            <Description path={description} loading={descriptionLoading} />
           </InfoField>
+
           <InfoField
             label="Justification"
             css={`
               margin-top: ${3 * GU}px;
             `}
           >
-            {ipfsJustification ? (
+            {justificationUrl ? (
               <Link
-                href={getIpfsUrlFromUri(ipfsJustification)}
+                href={justificationUrl}
                 css={`
                   max-width: 90%;
                 `}
@@ -177,13 +190,12 @@ function Details({ vote, status }) {
                 </span>
               </Link>
             ) : (
-              context
+              <p>{context}</p>
             )}
           </InfoField>
         </div>
-      ) : (
-        <InfoField label="Description">{context}</InfoField>
       )}
+
       <InfoField label="Status">
         <DisputableStatusLabel status={status} />
       </InfoField>

--- a/src/hooks/useAgreementDetails.js
+++ b/src/hooks/useAgreementDetails.js
@@ -7,7 +7,7 @@ import { getIpfsCidFromUri, ipfsGet } from '../lib/ipfs-utils'
 import { networkEnvironment } from '../current-environment'
 import { toMs } from '../utils/date-utils'
 import { useOrgApps } from '../providers/OrgApps'
-import { getAppPresentation } from '../lib/web3-utils'
+import { getAppPresentation } from '../utils/app-utils'
 
 const SUBGRAPH_URL = networkEnvironment.subgraphs?.agreement
 

--- a/src/hooks/useDescribeVote.js
+++ b/src/hooks/useDescribeVote.js
@@ -1,0 +1,90 @@
+import { useEffect, useState, useMemo } from 'react'
+import { describeScript } from '@aragon/connect'
+import { useOrganization } from '@aragon/connect-react'
+import { useOrgApps } from '../providers/OrgApps'
+import { getAppPresentation } from '../utils/app-utils'
+import { addressesEqual } from '../lib/web3-utils'
+
+const cachedDescriptions = new Map([])
+
+export function useDescribeVote(script, voteId) {
+  const [org] = useOrganization()
+  const { apps } = useOrgApps()
+  const [description, setDescription] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  const provider = org.connection.ethersProvider
+  const emptyScript = script === '0x00000001'
+
+  // Populate target app data from description
+  const targetApp = useMemo(
+    () =>
+      description
+        ? targetDataFromTransactionRequest(apps, description[0])
+        : null,
+    [apps, description]
+  )
+
+  useEffect(() => {
+    if (emptyScript) {
+      return
+    }
+
+    let cancelled = false
+
+    // Return early from cache if description is already available
+    if (cachedDescriptions.has(voteId)) {
+      if (!cancelled) {
+        setDescription(cachedDescriptions.get(voteId))
+        setLoading(false)
+      }
+
+      return
+    }
+
+    async function describe() {
+      try {
+        const description = await describeScript(script, apps, provider)
+
+        if (!cancelled) {
+          setDescription(description)
+          setLoading(false)
+
+          // Cache vote description to avoid additional calls
+          cachedDescriptions.set(voteId, description)
+        }
+      } catch (err) {
+        console.error(err)
+      }
+    }
+
+    describe()
+
+    return () => {
+      cancelled = true
+    }
+  }, [apps, emptyScript, provider, script, voteId])
+
+  return { description, emptyScript, loading, targetApp }
+}
+
+function targetDataFromTransactionRequest(apps, transactionRequest) {
+  const { to: targetAppAddress, name, identifier } = transactionRequest
+
+  // Populate via known org apps if we know about it
+  if (apps.some(({ address }) => addressesEqual(address, targetAppAddress))) {
+    const { humanName, iconSrc } = getAppPresentation(apps, targetAppAddress)
+    return {
+      address: targetAppAddress,
+      name: humanName,
+      icon: iconSrc,
+    }
+  }
+
+  // Otherwise provide the information we can
+  return {
+    address: targetAppAddress,
+    name: name || identifier,
+    icon: '',
+  }
+}

--- a/src/hooks/useDescribeVote.js
+++ b/src/hooks/useDescribeVote.js
@@ -16,7 +16,7 @@ export function useDescribeVote(script, voteId) {
   const provider = org.connection.ethersProvider
   const emptyScript = script === '0x00000001'
 
-  // Populate target app data from description
+  // Populate target app data from transacton request
   const targetApp = useMemo(
     () =>
       description
@@ -32,7 +32,7 @@ export function useDescribeVote(script, voteId) {
 
     let cancelled = false
 
-    // Return early from cache if description is already available
+    // Return from cache if description is was previously fetched
     if (cachedDescriptions.has(voteId)) {
       if (!cancelled) {
         setDescription(cachedDescriptions.get(voteId))
@@ -50,7 +50,7 @@ export function useDescribeVote(script, voteId) {
           setDescription(description)
           setLoading(false)
 
-          // Cache vote description to avoid additional calls
+          // Cache vote description to avoid unnecessary additional calls
           cachedDescriptions.set(voteId, description)
         }
       } catch (err) {
@@ -71,7 +71,7 @@ export function useDescribeVote(script, voteId) {
 function targetDataFromTransactionRequest(apps, transactionRequest) {
   const { to: targetAppAddress, name, identifier } = transactionRequest
 
-  // Populate via known org apps if we know about it
+  // Populate details via our apps list if it's available
   if (apps.some(({ address }) => addressesEqual(address, targetAppAddress))) {
     const { humanName, iconSrc } = getAppPresentation(apps, targetAppAddress)
     return {
@@ -81,7 +81,7 @@ function targetDataFromTransactionRequest(apps, transactionRequest) {
     }
   }
 
-  // Otherwise provide the information we can
+  // Otherwise provide some fallback values
   return {
     address: targetAppAddress,
     name: name || identifier,

--- a/src/hooks/useDescribeVote.js
+++ b/src/hooks/useDescribeVote.js
@@ -13,10 +13,12 @@ export function useDescribeVote(script, voteId) {
   const [description, setDescription] = useState(null)
   const [loading, setLoading] = useState(true)
 
+  // TODO: This provider will be supplied to describeScript by default in a future connect release
+  // https://github.com/aragon/connect/pull/223
   const provider = org.connection.ethersProvider
   const emptyScript = script === '0x00000001'
 
-  // Populate target app data from transacton request
+  // Populate target app data from transaction request
   const targetApp = useMemo(
     () =>
       description

--- a/src/hooks/useDescribeVote.js
+++ b/src/hooks/useDescribeVote.js
@@ -34,7 +34,7 @@ export function useDescribeVote(script, voteId) {
 
     let cancelled = false
 
-    // Return from cache if description is was previously fetched
+    // Return from cache if description was previously fetched
     if (cachedDescriptions.has(voteId)) {
       if (!cancelled) {
         setDescription(cachedDescriptions.get(voteId))
@@ -52,7 +52,7 @@ export function useDescribeVote(script, voteId) {
           setDescription(description)
           setLoading(false)
 
-          // Cache vote description to avoid unnecessary additional calls
+          // Cache vote description to avoid unnecessary future call
           cachedDescriptions.set(voteId, description)
         }
       } catch (err) {

--- a/src/hooks/useDisputableVotes.js
+++ b/src/hooks/useDisputableVotes.js
@@ -1,13 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { captureException } from '@sentry/browser'
-import { describeScript } from '@aragon/connect'
 import connectVoting from '@aragon/connect-disputable-voting'
 import { createAppHook } from '@aragon/connect-react'
 import { useOrgApps } from '../providers/OrgApps'
 import { networkEnvironment } from '../current-environment'
-import { getAppPresentation } from '../lib/web3-utils'
 
-const EMPTY_SCRIPT = '0x00000001'
 const SUBGRAPH_URL = networkEnvironment.subgraphs?.disputableVoting
 
 const connecterConfig = SUBGRAPH_URL && [
@@ -18,51 +15,21 @@ const connecterConfig = SUBGRAPH_URL && [
 const useDisputableVotingHook = createAppHook(connectVoting, connecterConfig)
 
 export function useDisputableVotes() {
-  const { apps, disputableVotingApp } = useOrgApps()
-  const [extendedVotesLoading, setExtendedVotesLoading] = useState(true)
-  const [extendedVotes, setExtendedVotes] = useState(null)
+  const { disputableVotingApp } = useOrgApps()
 
-  const [votes, { loading: votesLoading }] = useDisputableVotingHook(
+  const [votes, { loading }] = useDisputableVotingHook(
     disputableVotingApp,
     (app) => {
       return app.votes()
     }
   )
 
-  useEffect(() => {
-    let cancelled = false
-    async function getExtendedVotes() {
-      if (!cancelled) {
-        setExtendedVotesLoading(true)
-      }
+  const processedVotes = useMemo(
+    () => (votes ? votes.map((vote) => processVote(vote)) : null),
+    [votes]
+  )
 
-      try {
-        const processedVotes = await Promise.all(
-          votes.map(async (vote) =>
-            processVote(vote, apps, disputableVotingApp)
-          )
-        )
-
-        if (!cancelled) {
-          setExtendedVotes(processedVotes)
-          setExtendedVotesLoading(false)
-        }
-      } catch (err) {
-        captureException(err)
-        console.error(err)
-      }
-    }
-
-    if (!votesLoading) {
-      getExtendedVotes()
-    }
-
-    return () => {
-      cancelled = true
-    }
-  }, [apps, votes, votesLoading, disputableVotingApp])
-
-  return [extendedVotes, extendedVotesLoading]
+  return [processedVotes, loading]
 }
 
 export function useDisputableVote(proposalId) {
@@ -89,16 +56,15 @@ export function useDisputableVote(proposalId) {
       }
 
       try {
-        const [collateral, settings, processedVote] = await Promise.all([
+        const [collateral, settings] = await Promise.all([
           vote.collateralRequirement(),
           vote.setting(),
-          processVote(vote, apps, disputableVotingApp),
         ])
 
         const token = await collateral.token()
 
         const extendedVote = {
-          ...processedVote,
+          ...processVote(vote),
           settings: settings,
           collateral: collateral,
           token: token,
@@ -126,8 +92,8 @@ export function useDisputableVote(proposalId) {
   return [extendedVote, { loading: extendedVoteLoading }]
 }
 
-async function processVote(vote, apps, disputableVotingApp) {
-  const extendedVote = {
+function processVote(vote) {
+  return {
     ...vote,
     endDate: vote.endDate,
     formattedNays: vote.formattedNays,
@@ -139,45 +105,5 @@ async function processVote(vote, apps, disputableVotingApp) {
     naysPct: vote.naysPct,
     yeasPct: vote.yeasPct,
     status: vote.status,
-    target: getTargetData(apps, disputableVotingApp.address),
-  }
-
-  // Return disputableVotingApp as the default app target
-  if (vote.script === EMPTY_SCRIPT) {
-    return extendedVote
-  }
-
-  const description = await describeScript(vote.script, apps)
-  const voteHasAppTarget = description[0] && description[0].to
-
-  // If we have the target app on the description, build the target data with it instead
-  if (voteHasAppTarget) {
-    extendedVote.target = {
-      address: description[0].to,
-      name: description[0].name || description[0].identifier,
-    }
-  }
-
-  // If the target app is known to us then we can get it's icon and name
-  if (isKnownApp(apps, extendedVote.target.address)) {
-    extendedVote.target = getTargetData(apps, extendedVote.target.address)
-  }
-
-  return {
-    ...extendedVote,
-    description,
-  }
-}
-
-function isKnownApp(apps, appAddress) {
-  return apps && apps.filter((app) => app.address === appAddress).length > 0
-}
-
-function getTargetData(apps, address) {
-  const presentation = getAppPresentation(apps, address)
-  return {
-    address: address,
-    name: presentation.humanName,
-    icon: presentation.iconSrc,
   }
 }

--- a/src/lib/web3-utils.js
+++ b/src/lib/web3-utils.js
@@ -1,6 +1,3 @@
-import { getIpfsUrlFromUri } from '../lib/ipfs-utils'
-import { KNOWN_APPS } from '../utils/app-utils'
-
 export function getNetworkName(chainId) {
   chainId = String(chainId)
 
@@ -20,27 +17,4 @@ export function addressesEqual(first, second) {
   first = first && first.toLowerCase()
   second = second && second.toLowerCase()
   return first === second
-}
-
-export function getAppPresentation(apps, appAddress) {
-  const { contentUri, manifest, appId } = apps.find(
-    ({ address }) => address === appAddress
-  )
-  let iconSrc = ''
-  let humanName = ''
-  if (manifest && manifest.name) {
-    humanName = manifest.name
-  }
-
-  if (manifest && manifest.icons && manifest.icons[0]) {
-    const iconPath = manifest.icons[0].src
-    iconSrc = getIpfsUrlFromUri(contentUri) + iconPath
-  }
-
-  if (KNOWN_APPS.get(appId)) {
-    humanName = KNOWN_APPS.get(appId).humanName
-    iconSrc = KNOWN_APPS.get(appId).iconSrc
-  }
-
-  return { humanName, iconSrc }
 }

--- a/src/utils/app-utils.js
+++ b/src/utils/app-utils.js
@@ -1,8 +1,9 @@
 import iconAcl from '../assets/icon-acl.svg'
 import iconKernel from '../assets/icon-kernel.svg'
 import iconRegistry from '../assets/icon-registry.svg'
+import { getIpfsUrlFromUri } from '../lib/ipfs-utils'
 
-export const KNOWN_APPS = new Map([
+export const KNOW_SYSTEM_APPS = new Map([
   [
     '0x3b4bf6bf3ad5000ecf0f989d5befde585c6860fea3e574a4fab4c49d1c177d9c',
     {
@@ -25,3 +26,24 @@ export const KNOWN_APPS = new Map([
     },
   ],
 ])
+
+export function getAppPresentation(apps, appAddress) {
+  const { contentUri, manifest, appId } = apps.find(
+    ({ address }) => address === appAddress
+  )
+
+  // Get human readable name and icon from manifest if available
+  if (manifest && manifest.name && manifest.icons) {
+    const { name, icons } = manifest
+    const iconPath = icons[0].src
+
+    return {
+      humanName: name,
+      iconSrc: getIpfsUrlFromUri(contentUri) + iconPath,
+    }
+  }
+
+  // System apps don't have icons or readable names so use our
+  // static properties if possible
+  return KNOW_SYSTEM_APPS.get(appId) || null
+}

--- a/src/utils/app-utils.js
+++ b/src/utils/app-utils.js
@@ -3,7 +3,9 @@ import iconKernel from '../assets/icon-kernel.svg'
 import iconRegistry from '../assets/icon-registry.svg'
 import { getIpfsUrlFromUri } from '../lib/ipfs-utils'
 
-export const KNOW_SYSTEM_APPS = new Map([
+// TODO: Replace with information supplied by connect when available
+// https://github.com/aragon/connect/pull/259
+export const KNOWN_SYSTEM_APPS = new Map([
   [
     '0x3b4bf6bf3ad5000ecf0f989d5befde585c6860fea3e574a4fab4c49d1c177d9c',
     {
@@ -43,7 +45,7 @@ export function getAppPresentation(apps, appAddress) {
     }
   }
 
-  // System apps don't have icons or readable names so use our
-  // static properties if possible
-  return KNOW_SYSTEM_APPS.get(appId) || null
+  // System apps don't have icons or human readable names
+  // so we get them via a static mapping instead
+  return KNOWN_SYSTEM_APPS.get(appId) || null
 }

--- a/src/utils/app-utils.js
+++ b/src/utils/app-utils.js
@@ -1,7 +1,7 @@
+import { getIpfsUrlFromUri } from '../lib/ipfs-utils'
 import iconAcl from '../assets/icon-acl.svg'
 import iconKernel from '../assets/icon-kernel.svg'
 import iconRegistry from '../assets/icon-registry.svg'
-import { getIpfsUrlFromUri } from '../lib/ipfs-utils'
 
 // TODO: Replace with information supplied by connect when available
 // https://github.com/aragon/connect/pull/259


### PR DESCRIPTION
Fixes https://github.com/aragon/network-dashboard/issues/72

Improves our perceived performance by unblocking UI rendering and progressively loading each call to `describeScript`, we also now cache those descriptions in a mapping based on `vote.id` so that we don't have to do the same work multiple times.

![ezgif-7-354765a93a5a](https://user-images.githubusercontent.com/11708259/92106436-4ab22b80-eddc-11ea-8f42-34abec863276.gif)
