### PR TITLE
Global layout: Larger secondary columns, adjustable box

### DIFF
--- a/src/components/Agreement/Agreement.js
+++ b/src/components/Agreement/Agreement.js
@@ -1,11 +1,13 @@
 import React from 'react'
-import { Box, Button, Header, Split } from '@aragon/ui'
+import { Button, Header } from '@aragon/ui'
 import LayoutGutter from '../Layout/LayoutGutter'
 import LayoutLimiter from '../Layout/LayoutLimiter'
 import AgreementBindingActions from './AgreementBindingActions'
 import AgreementHeader from './AgreementHeader'
 import AgreementDetails from './AgreementDetails'
 import AgreementDocument from './AgreementDocument'
+import LayoutBox from '../Layout/LayoutBox'
+import LayoutColumns from '../Layout/LayoutColumns'
 import LoadingSection from '../Loading/LoadingSection'
 import { useAgreement } from '../../providers/Agreement'
 
@@ -40,10 +42,10 @@ function AgreementLayout({ agreementDetails }) {
   } = agreementDetails
 
   return (
-    <Split
+    <LayoutColumns
       primary={
         <>
-          <Box>
+          <LayoutBox primary>
             <AgreementHeader title={title} />
             <AgreementDetails
               contractAddress={contractAddress}
@@ -51,7 +53,7 @@ function AgreementLayout({ agreementDetails }) {
               ipfsUri={contentIpfsUri}
               stakingAddress={stakingAddress}
             />
-          </Box>
+          </LayoutBox>
           <AgreementDocument content={content} />
         </>
       }

--- a/src/components/Agreement/AgreementDetails.js
+++ b/src/components/Agreement/AgreementDetails.js
@@ -13,7 +13,7 @@ function AgreementDetails({
   stakingAddress,
 }) {
   const { layoutName } = useLayout()
-  const compactMode = layoutName === 'small'
+  const multiColumnsMode = layoutName === 'max' || layoutName === 'medium'
 
   return (
     <>
@@ -45,8 +45,8 @@ function AgreementDetails({
       <div
         css={`
           display: grid;
-          grid-gap: ${compactMode ? 3 * GU : 4 * GU}px;
-          grid-auto-flow: ${compactMode ? 'row' : 'column'};
+          grid-gap: ${multiColumnsMode ? 2 * GU : 3 * GU}px;
+          grid-auto-flow: ${multiColumnsMode ? 'column' : 'row'};
         `}
       >
         <InfoField label="Arbitrator">

--- a/src/components/Layout/LayoutBox.js
+++ b/src/components/Layout/LayoutBox.js
@@ -1,0 +1,61 @@
+import React, { useMemo } from 'react'
+import PropTypes from 'prop-types'
+import { Box, useLayout, useTheme, GU } from '@aragon/ui'
+
+function LayoutBox({ children, heading, primary, mode, ...props }) {
+  const { layoutName } = useLayout()
+  const theme = useTheme()
+  const compactMode = layoutName === 'small'
+
+  const { backgroundColor, borderColor } = useMemo(() => {
+    const attributes = {
+      warning: {
+        backgroundColor: '#fefdfb',
+        borderColor: theme.warning,
+      },
+      negative: {
+        backgroundColor: '#FFFAFA',
+        borderColor: '#FF7C7C',
+      },
+      disabled: {
+        backgroundColor: theme.surfacePressed,
+        borderColor: theme.border,
+      },
+    }
+
+    return attributes[mode] || {}
+  }, [theme, mode])
+
+  const primaryHeading = (
+    <span
+      css={`
+        padding: 0 ${2 * GU}px;
+      `}
+    >
+      {heading}
+    </span>
+  )
+
+  return (
+    <Box
+      {...props}
+      heading={heading && primary ? primaryHeading : heading}
+      padding={compactMode ? 2 * GU : primary && 5 * GU}
+      css={`
+        ${backgroundColor ? `background-color: ${backgroundColor};` : ''}
+        ${borderColor ? `border-color: ${borderColor};` : ''}
+      `}
+    >
+      {children}
+    </Box>
+  )
+}
+
+LayoutBox.propTypes = {
+  children: PropTypes.node,
+  heading: PropTypes.node,
+  mode: PropTypes.oneOf(['warning', 'negative', 'disabled']),
+  primary: PropTypes.bool,
+}
+
+export default LayoutBox

--- a/src/components/Layout/LayoutColumns.js
+++ b/src/components/Layout/LayoutColumns.js
@@ -10,6 +10,7 @@ function LayoutColumns({ primary, secondary }) {
     <div
       css={`
         flex-grow: 1;
+        min-width: 0;
       `}
     >
       {primary}
@@ -20,7 +21,6 @@ function LayoutColumns({ primary, secondary }) {
     <div
       css={`
         flex-shrink: 0;
-        min-width: 0;
         flex-grow: 0;
         width: ${oneColumn ? '100%' : `306px`};
         margin-left: ${!oneColumn ? 2 * GU : 0}px;

--- a/src/components/Layout/LayoutColumns.js
+++ b/src/components/Layout/LayoutColumns.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { useLayout, GU } from '@aragon/ui'
+
+function LayoutColumns({ primary, secondary }) {
+  const { layoutName } = useLayout()
+  const oneColumn = layoutName === 'small' || layoutName === 'medium'
+
+  const primaryContent = (
+    <div
+      css={`
+        flex-grow: 1;
+      `}
+    >
+      {primary}
+    </div>
+  )
+
+  const secondaryContent = (
+    <div
+      css={`
+        flex-shrink: 0;
+        min-width: 0;
+        flex-grow: 0;
+        width: ${oneColumn ? '100%' : `306px`};
+        margin-left: ${!oneColumn ? 2 * GU : 0}px;
+        margin-top: ${oneColumn ? 2 * GU : 0}px;
+      `}
+    >
+      {secondary}
+    </div>
+  )
+
+  return (
+    <div
+      css={`
+        display: ${oneColumn ? 'block' : 'flex'};
+      `}
+    >
+      {primaryContent}
+      {secondaryContent}
+    </div>
+  )
+}
+
+LayoutColumns.propTypes = {
+  primary: PropTypes.node,
+  secondary: PropTypes.node,
+}
+
+export default LayoutColumns

--- a/src/components/Proposals/ProposalCard.js
+++ b/src/components/Proposals/ProposalCard.js
@@ -37,7 +37,7 @@ function getAttributes(status, theme) {
   return (
     attributes[status] || {
       backgroundColor: theme.surface,
-      borderColor: theme.border,
+      borderColor: theme.surface,
       disabledProgressBars: false,
     }
   )
@@ -70,6 +70,7 @@ function ProposalCard({ vote, onProposalClick }) {
           align-items: start;
           padding: ${3 * GU}px;
           width: 100%;
+          height: 100%;
 
           background: ${backgroundColor};
           border: solid 1px ${borderColor};

--- a/src/components/Proposals/ProposalDetails/ProposalDetails.js
+++ b/src/components/Proposals/ProposalDetails/ProposalDetails.js
@@ -1,13 +1,11 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import {
-  Box,
   GU,
   IconCheck,
   IconLock,
   IdentityBadge,
   Link,
-  Split,
   Tag,
   TokenAmount,
   textStyle,
@@ -24,6 +22,8 @@ import {
 } from '../disputable-vote-statuses'
 import InfoField from '../../InfoField'
 import InfoBoxes from './InfoBoxes'
+import LayoutColumns from '../../Layout/LayoutColumns'
+import LayoutBox from '../../Layout/LayoutBox'
 import { safeDiv } from '../../../lib/math-utils'
 import SummaryBar from './SummaryBar'
 import SummaryRow from './SummaryRow'
@@ -33,90 +33,68 @@ import Description from '../Description'
 import { addressesEqual } from '../../../lib/web3-utils'
 import { getIpfsUrlFromUri } from '../../../lib/ipfs-utils'
 
-function getAttributes(status, theme) {
-  const attributes = {
-    [VOTE_STATUS_CANCELLED]: {
-      backgroundColor: theme.surfacePressed,
-      borderColor: theme.border,
-      disabledProgressBars: true,
-    },
-    [VOTE_STATUS_PAUSED]: {
-      backgroundColor: '#fefdfb',
-      borderColor: theme.warning,
-      disabledProgressBars: true,
-    },
-    [VOTE_STATUS_DISPUTED]: {
-      backgroundColor: '#FFFAFA',
-      borderColor: '#FF7C7C',
-      disabledProgressBars: true,
-    },
-  }
-
-  return (
-    attributes[status] || {
-      backgroundColor: theme.surface,
-      borderColor: theme.border,
-      disabledProgressBars: false,
-    }
-  )
-}
-
-function ProposalDetail({ vote }) {
-  const theme = useTheme()
-
+function ProposalDetails({ vote }) {
   const { voteId } = vote
   const disputableStatus = DISPUTABLE_VOTE_STATUSES.get(vote.status)
-  const { backgroundColor, borderColor, disabledProgressBars } = getAttributes(
-    disputableStatus,
-    theme
-  )
+
+  const { boxPresentation, disabledProgressBars } = useMemo(() => {
+    const disputablePresentation = {
+      [VOTE_STATUS_CANCELLED]: {
+        boxPresentation: 'disabled',
+        disabledProgressBars: true,
+      },
+      [VOTE_STATUS_PAUSED]: {
+        boxPresentation: 'warning',
+        disabledProgressBars: true,
+      },
+      [VOTE_STATUS_DISPUTED]: {
+        boxPresentation: 'negative',
+        disabledProgressBars: true,
+      },
+    }
+
+    return disputablePresentation[disputableStatus] || {}
+  }, [disputableStatus])
 
   // TODO: get youVoted flag from connector
   const youVoted = false
 
   return (
-    <Split
+    <LayoutColumns
       primary={
-        <>
-          <Box
+        <LayoutBox primary mode={boxPresentation}>
+          <div
             css={`
-              background: ${backgroundColor};
-              border: solid 1px ${borderColor};
+              display: grid;
+              grid-auto-flow: row;
+
+              grid-gap: ${4 * GU}px;
             `}
           >
-            <div
-              css={`
-                display: grid;
-                grid-auto-flow: row;
-
-                grid-gap: ${4 * GU}px;
-              `}
-            >
-              {youVoted && (
-                <div
-                  css={`
-                    display: flex;
-                  `}
-                >
-                  <Tag icon={<IconCheck size="small" />} label="Voted" />
-                </div>
-              )}
-              <h1
+            {youVoted && (
+              <div
                 css={`
-                  ${textStyle('title2')};
-                  font-weight: bold;
+                  display: flex;
                 `}
               >
-                Vote #{voteId}
-              </h1>
-              <Details vote={vote} status={disputableStatus} />
-              <SummaryInfo
-                vote={vote}
-                disabledProgressBars={disabledProgressBars}
-              />
-            </div>
-          </Box>
-        </>
+                <Tag icon={<IconCheck size="small" />} label="Voted" />
+              </div>
+            )}
+            <h1
+              css={`
+                ${textStyle('title2')};
+                font-weight: bold;
+              `}
+            >
+              Vote #{voteId}
+            </h1>
+            <Details vote={vote} status={disputableStatus} />
+            <SummaryInfo
+              vote={vote}
+              disabledProgressBars={disabledProgressBars}
+            />
+          </div>
+        </LayoutBox>
       }
       secondary={
         <>
@@ -132,7 +110,7 @@ function ProposalDetail({ vote }) {
 function Details({ vote, status }) {
   const { context, creator, collateral, token, description } = vote
   const { layoutName } = useLayout()
-  const compactMode = layoutName === 'small'
+  const twoColumnMode = layoutName === 'max'
 
   let ipfsJustification = null
   if (context.startsWith('ipfs')) {
@@ -143,7 +121,7 @@ function Details({ vote, status }) {
       css={`
         display: grid;
 
-        grid-template-columns: ${compactMode ? '1fr' : `1fr ${30 * GU}px`};
+        grid-template-columns: ${twoColumnMode ? `1fr ${30 * GU}px` : '1fr'};
         grid-gap: ${3 * GU}px;
       `}
     >
@@ -302,8 +280,8 @@ function SummaryInfo({ vote, disabledProgressBars }) {
 }
 /* eslint-disable react/prop-types */
 
-ProposalDetail.propTypes = {
+ProposalDetails.propTypes = {
   vote: PropTypes.object,
 }
 
-export default ProposalDetail
+export default ProposalDetails

--- a/src/style/breakpoints.js
+++ b/src/style/breakpoints.js
@@ -2,6 +2,6 @@ export const breakpoints = {
   min: 360,
   small: 680,
   medium: 720,
-  large: 960,
+  large: 1080,
   max: 1280,
 }


### PR DESCRIPTION
Fixes https://github.com/aragon/network-dashboard/issues/19

This PR adds custom column layout and adjustable box. This is needed because our UI kit has a lot of opinions about how it would like to present these, and optimises for apps with a sidebar. Our designs need a larger right hand column, and the ability to easily adjust the box padding depending on the context.

I also moved the disputable colouring into the new `LayoutBox` as a `mode` that can be optionally provided.

These changes also fix some overflow blowout we had at smaller viewport sizes.

![image](https://user-images.githubusercontent.com/11708259/92158094-4bba7b80-ee23-11ea-989e-aba7a0fc0e6e.png)
