### PR TITLE
Spring: Prefer renderprops, centralize custom springs

### DIFF
--- a/src/components/Loading/LoadingFullscreen.js
+++ b/src/components/Loading/LoadingFullscreen.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { useSpring, animated } from 'react-spring'
 import { keyframes, css } from 'styled-components'
 import { useTheme, GU } from '@aragon/ui'
+import { springs } from '../../style/springs'
 
 const AnimatedDiv = animated.div
 
@@ -22,7 +23,7 @@ function LoadingFullscreen({ ...props }) {
   const theme = useTheme()
 
   const ringTransitionIn = useSpring({
-    config: { mass: 1, tension: 200, friction: 20 },
+    config: springs.gentle,
     from: { opacity: 0, transform: `scale3d(1.5, 1.5, 1)` },
     to: { opacity: 1, transform: `scale3d(1, 1, 1)` },
   })

--- a/src/components/Loading/LoadingSection.js
+++ b/src/components/Loading/LoadingSection.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { useTransition, animated } from 'react-spring'
+import { Transition, animated } from 'react-spring/renderprops'
 import styled from 'styled-components'
 import { Box, textStyle, LoadingRing, GU } from '@aragon/ui'
 import loadingGraphic from '../../assets/loading.svg'
+import { springs } from '../../style/springs'
 
 const AnimatedDiv = styled(animated.div)`
   top: 0;
@@ -12,97 +13,96 @@ const AnimatedDiv = styled(animated.div)`
 `
 
 function LoadingSection({ children, loading, title }) {
-  const loadingSwapTransitions = useTransition(loading, null, {
-    config: { mass: 1, tension: 200, friction: 20 },
-    from: { opacity: 0, transform: `translate3d(0, ${0.5 * GU}px, 0)` },
-    enter: { opacity: 1, transform: `translate3d(0, 0, 0)` },
-    leave: {
-      opacity: 0,
-      position: 'absolute',
-      transform: `translate3d(0, -${0.5 * GU}px, 0)`,
-    },
-  })
-
   return (
     <div
       css={`
         position: relative;
       `}
     >
-      {loadingSwapTransitions.map(({ item: loading, key, props }) =>
-        loading ? (
-          <AnimatedDiv style={props} key={key}>
-            <Box>
-              <div
-                css={`
-                  display: flex;
-                  flex-direction: column;
-                  align-items: center;
-                  justify-content: center;
-                  padding-top: ${11 * GU}px;
-                  padding-bottom: ${11 * GU}px;
-                `}
-              >
-                <div
-                  css={`
-                    max-width: 100%;
-                    width: ${34 * GU}px;
-                  `}
-                >
-                  <div
-                    css={`
-                      position: relative;
-
-                      /* Match aspect ratio of loading graphic to reserve space during initial load */
-                      padding-top: 58.5%;
-                    `}
-                  >
-                    <img
-                      src={loadingGraphic}
-                      alt=""
+      <Transition
+        items={loading}
+        config={springs.gentle}
+        from={{ opacity: 0, transform: `translate3d(0, ${0.5 * GU}px, 0)` }}
+        enter={{ opacity: 1, transform: `translate3d(0, 0, 0)` }}
+        leave={{
+          opacity: 0,
+          position: 'absolute',
+          transform: `translate3d(0, -${0.5 * GU}px, 0)`,
+        }}
+      >
+        {(loading) =>
+          loading
+            ? (props) => (
+                <AnimatedDiv style={props}>
+                  <Box>
+                    <div
                       css={`
-                        display: block;
-                        position: absolute;
-                        top: 0;
-                        left: 0;
-                        width: 100%;
+                        display: flex;
+                        flex-direction: column;
+                        align-items: center;
+                        justify-content: center;
+                        padding-top: ${11 * GU}px;
+                        padding-bottom: ${11 * GU}px;
                       `}
-                    />
-                  </div>
-                </div>
+                    >
+                      <div
+                        css={`
+                          max-width: 100%;
+                          width: ${34 * GU}px;
+                        `}
+                      >
+                        <div
+                          css={`
+                            position: relative;
 
-                <span
-                  css={`
-                    display: flex;
-                    align-items: center;
-                    margin-top: ${4 * GU}px;
-                  `}
-                >
-                  <div
-                    css={`
-                      margin-right: 16px;
-                    `}
-                  >
-                    <LoadingRing mode="half-circle" />
-                  </div>
-                  <h2
-                    css={`
-                      ${textStyle('title3')}
-                      line-height: 1.2;
-                    `}
-                  >
-                    {title}…
-                  </h2>
-                </span>
-              </div>
-            </Box>
-          </AnimatedDiv>
-        ) : (
-          <AnimatedDiv style={props} key={key}>
-            {children}
-          </AnimatedDiv>
-        )
-      )}
+                            /* Match aspect ratio of loading graphic to reserve space during initial load */
+                            padding-top: 58.5%;
+                          `}
+                        >
+                          <img
+                            src={loadingGraphic}
+                            alt=""
+                            css={`
+                              display: block;
+                              position: absolute;
+                              top: 0;
+                              left: 0;
+                              width: 100%;
+                            `}
+                          />
+                        </div>
+                      </div>
+
+                      <span
+                        css={`
+                          display: flex;
+                          align-items: center;
+                          margin-top: ${4 * GU}px;
+                        `}
+                      >
+                        <div
+                          css={`
+                            margin-right: 16px;
+                          `}
+                        >
+                          <LoadingRing mode="half-circle" />
+                        </div>
+                        <h2
+                          css={`
+                            ${textStyle('title3')}
+                            line-height: 1.2;
+                          `}
+                        >
+                          {title}…
+                        </h2>
+                      </span>
+                    </div>
+                  </Box>
+                </AnimatedDiv>
+              )
+            : (props) => <AnimatedDiv style={props}>{children}</AnimatedDiv>
+        }
+      </Transition>
     </div>
   )
 }

--- a/src/components/MainView.js
+++ b/src/components/MainView.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { useTransition, animated } from 'react-spring'
+import { Transition, animated } from 'react-spring/renderprops'
 import { ScrollView, GU } from '@aragon/ui'
 import LoadingFullscreen from '../components/Loading/LoadingFullscreen'
 import Header from './Header/Header'
@@ -10,12 +10,6 @@ const AnimatedDiv = animated.div
 
 const MainView = React.memo(function MainView({ children }) {
   const { loading } = useOrgApps()
-
-  const loaderExitTransitions = useTransition(loading, null, {
-    from: { opacity: 0 },
-    enter: { opacity: 1 },
-    leave: { opacity: 0 },
-  })
 
   return (
     <div
@@ -61,18 +55,23 @@ const MainView = React.memo(function MainView({ children }) {
                 padding-bottom: ${12 * GU}px;
               `}
             >
-              {children}
+              {!loading && children}
             </main>
           </ScrollView>
         </div>
       )}
 
-      {loaderExitTransitions.map(
-        ({ item: loading, key, props }) =>
-          loading && (
+      <Transition
+        items={loading}
+        from={{ opacity: 0 }}
+        enter={{ opacity: 1 }}
+        leave={{ opacity: 0 }}
+      >
+        {(loading) =>
+          loading &&
+          ((props) => (
             <AnimatedDiv
               style={props}
-              key={key}
               css={`
                 display: flex;
                 position: absolute;
@@ -91,8 +90,9 @@ const MainView = React.memo(function MainView({ children }) {
                 `}
               />
             </AnimatedDiv>
-          )
-      )}
+          ))
+        }
+      </Transition>
     </div>
   )
 })

--- a/src/style/springs.js
+++ b/src/style/springs.js
@@ -1,0 +1,6 @@
+import { springs as baseSprings } from '@aragon/ui'
+
+export const springs = {
+  ...baseSprings,
+  gentle: { mass: 1, tension: 200, friction: 20 },
+}


### PR DESCRIPTION
I ran into some issues in another piece of code where hooks were being inconsistent. For this reason I think it's best if we default to the [renderprops api](https://www.react-spring.io/docs/props/spring) for animation.

Hoped the version bump to v8 would solve most of the problems, it seems not..