### PR TITLE
Environment: Temp switch to theGraph endpoints

### DIFF
--- a/src/configuration/networks.js
+++ b/src/configuration/networks.js
@@ -47,11 +47,11 @@ export default new Map([
       ipfsGateway: 'https://ipfs.eth.aragon.network/ipfs',
       subgraphs: {
         organization:
-          'https://graph.backend.aragon.org/subgraphs/name/aragon/aragon-rinkeby-staging',
+          'https://api.thegraph.com/subgraphs/name/aragon/aragon-rinkeby',
         disputableVoting:
-          'https://graph.backend.aragon.org/subgraphs/name/aragon/aragon-dvoting-rinkeby-staging',
+          'https://api.thegraph.com/subgraphs/name/aragon/aragon-dvoting-rinkeby-staging',
         agreement:
-          'https://graph.backend.aragon.org/subgraphs/name/aragon/aragon-agreement-rinkeby-staging',
+          'https://api.thegraph.com/subgraphs/name/aragon/aragon-agreement-rinkeby-staging',
       },
     },
   ],


### PR DESCRIPTION
Rinkeby is failing to load org on hosted graphs, switch to theGraph temporarily to fix and get the preview deploys working again.