### PR TITLE
Agreement: Request markdown data at component level

### DIFF
--- a/src/components/Agreement/Agreement.js
+++ b/src/components/Agreement/Agreement.js
@@ -55,7 +55,6 @@ const Agreement = React.memo(function Agreement() {
 function AgreementLayout({ agreement, signedAgreement }) {
   const {
     title,
-    content,
     contractAddress,
     contentIpfsUri,
     effectiveFrom,
@@ -77,7 +76,7 @@ function AgreementLayout({ agreement, signedAgreement }) {
               signedAgreement={signedAgreement}
             />
           </LayoutBox>
-          <AgreementDocument content={content} />
+          <AgreementDocument ipfsUri={contentIpfsUri} />
         </>
       }
       secondary={<AgreementBindingActions disputableApps={disputableApps} />}


### PR DESCRIPTION
- More scalable if the transfer sizes somehow increases dramatically
- Keeps `useAgreement` clean of async side effects which were delaying the UI from updating state on things like "Has been signed" which just looked janky.
- Can fail gracefully without killing other parts of the view