### PR TITLE
Performance: Reduce calls to describeScript

### DIFF
--- a/src/components/Proposals/ProposalCard.js
+++ b/src/components/Proposals/ProposalCard.js
@@ -7,7 +7,7 @@ import {
   VOTE_STATUS_DISPUTED,
   VOTE_STATUS_CHALLENGED,
 } from './disputable-vote-statuses'
-import { useDescribeVote } from '../../hooks/useDescribeVote'
+import { useDescribeScript } from '../../hooks/useDescribeScript'
 import Description from './Description'
 import DisputableStatusLabel from './DisputableStatusLabel'
 import LoadingSkeleton from '../Loading/LoadingSkeleton'
@@ -45,11 +45,7 @@ function getAttributes(status, theme) {
 function ProposalCard({ vote, onProposalClick }) {
   const theme = useTheme()
   const { context, voteId, script, id } = vote
-  const {
-    description,
-    emptyScript,
-    loading: descriptionLoading,
-  } = useDescribeVote(script, id)
+  const { description, targetApp, status } = useDescribeScript(script, id)
 
   const disputableStatus = DISPUTABLE_VOTE_STATUSES.get(vote.status)
   const { backgroundColor, borderColor, disabledProgressBars } = getAttributes(
@@ -86,7 +82,11 @@ function ProposalCard({ vote, onProposalClick }) {
             }
           `}
         >
-          <TargetAppBadge script={script} voteId={id} />
+          <TargetAppBadge
+            useDefaultBadge={status.emptyScript}
+            targetApp={targetApp}
+            loading={status.loading}
+          />
         </div>
 
         <div
@@ -105,7 +105,7 @@ function ProposalCard({ vote, onProposalClick }) {
           overflow: hidden;
         `}
         >
-          {emptyScript ? (
+          {status.emptyScript ? (
             <p>
               <strong css="font-weight: bold">#{voteId}: </strong>
               {context || 'No description provided'}
@@ -113,7 +113,7 @@ function ProposalCard({ vote, onProposalClick }) {
           ) : (
             <DescriptionWithSkeleton
               description={description}
-              loading={descriptionLoading}
+              loading={status.loading}
               voteNumber={voteId}
             />
           )}

--- a/src/components/Proposals/ProposalDetails/ProposalDetails.js
+++ b/src/components/Proposals/ProposalDetails/ProposalDetails.js
@@ -141,7 +141,7 @@ function ProposalDetails({ vote }) {
                 status={disputableStatus}
                 emptyScript={status.emptyScript}
                 description={description}
-                loading={status.loading}
+                descriptionLoading={status.loading}
               />
               <SummaryInfo
                 vote={vote}
@@ -203,7 +203,13 @@ function ProposalDetails({ vote }) {
 }
 
 /* eslint-disable react/prop-types */
-function Details({ vote, status, loading, emptyScript, description }) {
+function Details({
+  vote,
+  disputableStatus,
+  descriptionLoading,
+  emptyScript,
+  description,
+}) {
   const { context, creator, collateral, collateralToken } = vote
 
   const { layoutName } = useLayout()
@@ -219,7 +225,6 @@ function Details({ vote, status, loading, emptyScript, description }) {
     <div
       css={`
         display: grid;
-
         grid-template-columns: ${twoColumnMode ? `1fr ${30 * GU}px` : '1fr'};
         grid-gap: ${3 * GU}px;
       `}
@@ -233,7 +238,7 @@ function Details({ vote, status, loading, emptyScript, description }) {
           <InfoField label="Description">
             <DescriptionWithSkeleton
               description={description}
-              loading={loading}
+              loading={descriptionLoading}
             />
           </InfoField>
 
@@ -269,7 +274,7 @@ function Details({ vote, status, loading, emptyScript, description }) {
       )}
 
       <InfoField label="Status">
-        <DisputableStatusLabel status={status} />
+        <DisputableStatusLabel status={disputableStatus} />
       </InfoField>
 
       <InfoField label="Action collateral">

--- a/src/components/Proposals/ProposalDetails/ProposalDetails.js
+++ b/src/components/Proposals/ProposalDetails/ProposalDetails.js
@@ -138,7 +138,7 @@ function ProposalDetails({ vote }) {
               </h1>
               <Details
                 vote={vote}
-                status={disputableStatus}
+                disputableStatus={disputableStatus}
                 emptyScript={status.emptyScript}
                 description={description}
                 descriptionLoading={status.loading}

--- a/src/components/Proposals/ProposalDetails/ProposalDetails.js
+++ b/src/components/Proposals/ProposalDetails/ProposalDetails.js
@@ -37,7 +37,7 @@ import VoteCast from './VoteCast'
 import TargetAppBadge from '../TargetAppBadge'
 import { addressesEqual } from '../../../lib/web3-utils'
 import { getIpfsUrlFromUri } from '../../../lib/ipfs-utils'
-import { useDescribeVote } from '../../../hooks/useDescribeVote'
+import { useDescribeScript } from '../../../hooks/useDescribeScript'
 import LoadingSkeleton from '../../Loading/LoadingSkeleton'
 import { useWallet } from '../../../providers/Wallet'
 import { toMs } from '../../../utils/date-utils'
@@ -75,6 +75,8 @@ function ProposalDetails({ vote }) {
   const [voteSupported, setVoteSupported] = useState(false)
   const { actionId, voteId, id, script, voterInfo, orgToken } = vote
   const disputableStatus = DISPUTABLE_VOTE_STATUSES.get(vote.status)
+
+  const { description, targetApp, status } = useDescribeScript(script, id)
 
   const { boxPresentation, disabledProgressBars } = useMemo(
     () => getPresentation(disputableStatus),
@@ -117,7 +119,11 @@ function ProposalDetails({ vote }) {
                   justify-content: space-between;
                 `}
               >
-                <TargetAppBadge script={script} voteId={id} />
+                <TargetAppBadge
+                  useDefaultBadge={status.emptyScript}
+                  targetApp={targetApp}
+                  loading={status.loading}
+                />
                 {accountHasVoted && (
                   <Tag icon={<IconCheck size="small" />} label="Voted" />
                 )}
@@ -130,7 +136,13 @@ function ProposalDetails({ vote }) {
               >
                 Vote #{voteId}
               </h1>
-              <Details vote={vote} status={disputableStatus} />
+              <Details
+                vote={vote}
+                status={disputableStatus}
+                emptyScript={status.emptyScript}
+                description={description}
+                loading={status.loading}
+              />
               <SummaryInfo
                 vote={vote}
                 disabledProgressBars={disabledProgressBars}
@@ -191,13 +203,8 @@ function ProposalDetails({ vote }) {
 }
 
 /* eslint-disable react/prop-types */
-function Details({ vote, status }) {
-  const { context, creator, collateral, collateralToken, script } = vote
-  const {
-    description,
-    emptyScript,
-    loading: descriptionLoading,
-  } = useDescribeVote(script, vote.id)
+function Details({ vote, status, loading, emptyScript, description }) {
+  const { context, creator, collateral, collateralToken } = vote
 
   const { layoutName } = useLayout()
 
@@ -226,7 +233,7 @@ function Details({ vote, status }) {
           <InfoField label="Description">
             <DescriptionWithSkeleton
               description={description}
-              loading={descriptionLoading}
+              loading={loading}
             />
           </InfoField>
 

--- a/src/components/Proposals/TargetAppBadge.js
+++ b/src/components/Proposals/TargetAppBadge.js
@@ -1,17 +1,14 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { AppBadge, GU } from '@aragon/ui'
-import { useDescribeVote } from '../../hooks/useDescribeVote'
 import { useOrgApps } from '../../providers/OrgApps'
 import { getAppPresentation } from '../../utils/app-utils'
 import LoadingSkeleton from '../Loading/LoadingSkeleton'
 
-/* eslint-disable react/prop-types */
-function TargetAppBadge({ script, voteId }) {
-  const { emptyScript, targetApp, loading } = useDescribeVote(script, voteId)
-
+function TargetAppBadge({ useDefaultBadge, targetApp, loading }) {
   return (
     <>
-      {emptyScript ? (
+      {useDefaultBadge ? (
         <DefaultAppBadge />
       ) : (
         <AppBadgeWithSkeleton targetApp={targetApp} loading={loading} />
@@ -20,13 +17,11 @@ function TargetAppBadge({ script, voteId }) {
   )
 }
 
+/* eslint-disable react/prop-types */
 function DefaultAppBadge() {
-  const { apps, disputableVotingApp } = useOrgApps()
+  const { disputableVotingApp } = useOrgApps()
 
-  const { humanName, iconSrc } = getAppPresentation(
-    apps,
-    disputableVotingApp.address
-  )
+  const { humanName, iconSrc } = getAppPresentation(disputableVotingApp)
 
   return (
     <AppBadge
@@ -62,5 +57,11 @@ function AppBadgeWithSkeleton({ targetApp, loading }) {
   )
 }
 /* eslint-disable react/prop-types */
+
+TargetAppBadge.propTypes = {
+  useDefaultBadge: PropTypes.bool,
+  targetApp: PropTypes.object,
+  loading: PropTypes.bool,
+}
 
 export default TargetAppBadge

--- a/src/current-environment.js
+++ b/src/current-environment.js
@@ -30,25 +30,15 @@ const agreementSubgraph = networkEnvironment.subgraphs?.agreement
 const disputableVotingSubgraph = networkEnvironment.subgraphs?.disputableVoting
 const orgSubgraph = networkEnvironment.subgraphs?.organization
 
-export const connector = {
-  org: {
-    connectorConfig: orgSubgraph && [
-      'thegraph',
-      { orgSubgraphUrl: orgSubgraph },
-    ],
-  },
-  agreement: {
-    appName: 'agreement',
-    connectorConfig: agreementSubgraph && [
-      'thegraph',
-      { subgraphUrl: agreementSubgraph },
-    ],
-  },
-  disputableVoting: {
-    appName: 'disputable-voting',
-    connectorConfig: disputableVotingSubgraph && [
-      'thegraph',
-      { subgraphUrl: disputableVotingSubgraph },
-    ],
-  },
+export const connectorConfig = {
+  org: orgSubgraph && ['thegraph', { orgSubgraphUrl: orgSubgraph }],
+  agreement: agreementSubgraph && [
+    'thegraph',
+    { subgraphUrl: agreementSubgraph },
+  ],
+
+  disputableVoting: disputableVotingSubgraph && [
+    'thegraph',
+    { subgraphUrl: disputableVotingSubgraph },
+  ],
 }

--- a/src/hooks/useActions.js
+++ b/src/hooks/useActions.js
@@ -7,19 +7,19 @@ import { useMounted } from '../hooks/useMounted'
 export function useActions() {
   const mounted = useMounted()
   const { account } = useWallet()
-  const { agreementApp, disputableVotingApp } = useOrgApps()
+  const { connectedAgreementApp, connectedDisputableVotingApp } = useOrgApps()
 
   const signAgreement = useCallback(
     async ({ versionId }, onDone = noop) => {
       catchErrors(async () => {
-        const intent = await agreementApp.sign(account, versionId)
+        const intent = await connectedAgreementApp.sign(account, versionId)
 
         if (mounted()) {
           onDone(intent)
         }
       })
     },
-    [account, agreementApp, mounted]
+    [account, connectedAgreementApp, mounted]
   )
 
   const challengeProposal = useCallback(
@@ -28,7 +28,7 @@ export function useActions() {
       onDone = noop
     ) => {
       catchErrors(async () => {
-        const intent = await agreementApp.challenge(
+        const intent = await connectedAgreementApp.challenge(
           actionId,
           settlementOffer,
           finishedEvidence,
@@ -41,26 +41,26 @@ export function useActions() {
         }
       })
     },
-    [account, agreementApp, mounted]
+    [account, connectedAgreementApp, mounted]
   )
 
   const settleDispute = useCallback(
     async ({ actionId }, onDone = noop) => {
       catchErrors(async () => {
-        const intent = await agreementApp.settle(actionId, account)
+        const intent = await connectedAgreementApp.settle(actionId, account)
 
         if (mounted()) {
           onDone(intent)
         }
       })
     },
-    [account, agreementApp, mounted]
+    [account, connectedAgreementApp, mounted]
   )
 
   const voteOnProposal = useCallback(
     async ({ voteId, voteSupported }, onDone = noop) => {
       catchErrors(async () => {
-        const intent = await disputableVotingApp.castVote(
+        const intent = await connectedDisputableVotingApp.castVote(
           voteId,
           voteSupported,
           account
@@ -71,7 +71,7 @@ export function useActions() {
         }
       })
     },
-    [account, disputableVotingApp, mounted]
+    [account, connectedDisputableVotingApp, mounted]
   )
 
   const actions = useMemo(

--- a/src/hooks/useAgreement.js
+++ b/src/hooks/useAgreement.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { utils as ethersUtils } from 'ethers'
+import { addressesEqual } from '../lib/web3-utils'
 import { captureErrorWithSentry } from '../sentry'
 import { toMs } from '../utils/date-utils'
 import { useOrgApps } from '../providers/OrgApps'
@@ -60,9 +61,13 @@ export function useAgreement() {
 function processDisputableApps(apps, disputableApps) {
   // Add presentation information and value formatting for each app
   const processedDisputableApps = disputableApps.map((disputableApp) => {
-    const { address, challengeDuration } = disputableApp
+    const { address: disputableAppAddress, challengeDuration } = disputableApp
 
-    const { iconSrc, humanName } = getAppPresentation(apps, address)
+    const app = apps.find(({ address }) =>
+      addressesEqual(address, disputableAppAddress)
+    )
+
+    const { iconSrc, humanName } = getAppPresentation(app)
 
     return {
       ...disputableApp,

--- a/src/hooks/useDisputableVotes.js
+++ b/src/hooks/useDisputableVotes.js
@@ -7,7 +7,7 @@ import { useMounted } from '../hooks/useMounted'
 
 export function useDisputableVote(proposalId) {
   const mounted = useMounted()
-  const { apps, disputableVotingApp, appsLoading } = useOrgApps()
+  const { apps, connectedDisputableVotingApp, appsLoading } = useOrgApps()
   const { account } = useWallet()
   const [processedVote, setProcessedVote] = useState(null)
   const [processedVoteLoading, setProcessedVoteLoading] = useState(true)
@@ -19,8 +19,8 @@ export function useDisputableVote(proposalId) {
       }
 
       try {
-        const vote = await disputableVotingApp.vote(
-          `${disputableVotingApp.address}-vote-${proposalId}`
+        const vote = await connectedDisputableVotingApp.vote(
+          `${connectedDisputableVotingApp.address}-vote-${proposalId}`
         )
 
         const [
@@ -90,10 +90,17 @@ export function useDisputableVote(proposalId) {
       }
     }
 
-    if (!appsLoading && disputableVotingApp) {
+    if (!appsLoading && connectedDisputableVotingApp) {
       getExtendedVote()
     }
-  }, [apps, appsLoading, disputableVotingApp, proposalId, mounted, account])
+  }, [
+    apps,
+    appsLoading,
+    connectedDisputableVotingApp,
+    proposalId,
+    mounted,
+    account,
+  ])
 
   return [processedVote, processedVoteLoading]
 }

--- a/src/providers/AgreementSubscription.js
+++ b/src/providers/AgreementSubscription.js
@@ -3,14 +3,12 @@ import PropTypes from 'prop-types'
 import connectAgreement from '@aragon/connect-agreement'
 import { captureErrorWithSentry } from '../sentry'
 import { createAppHook } from '@aragon/connect-react'
-import { connector } from '../current-environment'
+import { connectorConfig } from '../current-environment'
 import { useWallet } from '../providers/Wallet'
 import { useMounted } from '../hooks/useMounted'
 import { useOrgApps } from '../providers/OrgApps'
 
-const { agreement } = connector
-
-const useAgreement = createAppHook(connectAgreement, agreement.connectorConfig)
+const useAgreement = createAppHook(connectAgreement, connectorConfig.agreement)
 const AgreementSubscriptionContext = React.createContext()
 
 function AgreementSubscriptionProvider({ children }) {

--- a/src/providers/AgreementSubscription.js
+++ b/src/providers/AgreementSubscription.js
@@ -2,10 +2,11 @@ import React, { useContext, useMemo, useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import connectAgreement from '@aragon/connect-agreement'
 import { captureErrorWithSentry } from '../sentry'
-import { createAppHook, useApp } from '@aragon/connect-react'
+import { createAppHook } from '@aragon/connect-react'
 import { connector } from '../current-environment'
 import { useWallet } from '../providers/Wallet'
 import { useMounted } from '../hooks/useMounted'
+import { useOrgApps } from '../providers/OrgApps'
 
 const { agreement } = connector
 
@@ -14,7 +15,8 @@ const AgreementSubscriptionContext = React.createContext()
 
 function AgreementSubscriptionProvider({ children }) {
   const { account } = useWallet()
-  const [agreementApp, agreementAppStatus] = useApp(agreement.appName)
+  const { agreementApp } = useOrgApps()
+
   const [currentVersion, currentVersionStatus] = useAgreement(
     agreementApp,
     (app) => app.onCurrentVersion()
@@ -43,7 +45,6 @@ function AgreementSubscriptionProvider({ children }) {
 
   // TODO: Tidy this once we have an improved connect-react api
   const loading =
-    agreementAppStatus.loading ||
     currentVersionStatus.loading ||
     disputableAppsStatus.loading ||
     signerStatus.loading ||
@@ -51,7 +52,6 @@ function AgreementSubscriptionProvider({ children }) {
     appsWithRequirementsLoading
 
   const error =
-    agreementAppStatus.error ||
     currentVersionStatus.error ||
     disputableAppsStatus.error ||
     signerStatus.error ||

--- a/src/providers/Connect.js
+++ b/src/providers/Connect.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Connect } from '@aragon/connect-react'
-import { connector, networkEnvironment } from '../current-environment'
-
-const { org } = connector
+import { connectorConfig, networkEnvironment } from '../current-environment'
 
 function ConnectProvider({ children }) {
   const { chainId, orgLocation } = networkEnvironment
@@ -11,7 +9,7 @@ function ConnectProvider({ children }) {
   return (
     <Connect
       location={orgLocation}
-      connector={org.connectorConfig || 'thegraph'}
+      connector={connectorConfig.org || 'thegraph'}
       options={{
         network: chainId,
       }}

--- a/src/providers/OrgApps.js
+++ b/src/providers/OrgApps.js
@@ -4,9 +4,7 @@ import connectAgreement from '@aragon/connect-agreement'
 import connectVoting from '@aragon/connect-disputable-voting'
 import { useApps, createAppHook, useOrganization } from '@aragon/connect-react'
 import { captureErrorWithSentry } from '../sentry'
-import { connector } from '../current-environment'
-
-const { agreement, disputableVoting } = connector
+import { connectorConfig } from '../current-environment'
 
 function getAppByName(apps, appName) {
   return apps.find(({ name }) => name === appName) || null
@@ -16,20 +14,20 @@ const OrgAppsContext = React.createContext()
 
 const useAgreementHook = createAppHook(
   connectAgreement,
-  agreement.connectorConfig
+  connectorConfig.agreement
 )
 
 const useDisputableVotingHook = createAppHook(
   connectVoting,
-  disputableVoting.connectorConfig
+  connectorConfig.disputableVoting
 )
 
 function OrgAppsProvider({ children }) {
   const [apps, { loading: orgAppsLoading, error: appsError }] = useApps()
   const [org, { loading: orgLoading, error: orgError }] = useOrganization()
 
-  const agreementApp = getAppByName(apps, agreement.appName)
-  const disputableVotingApp = getAppByName(apps, disputableVoting.appName)
+  const agreementApp = getAppByName(apps, 'agreement')
+  const disputableVotingApp = getAppByName(apps, 'disputable-voting')
 
   const [
     connectedAgreementApp,
@@ -38,15 +36,12 @@ function OrgAppsProvider({ children }) {
 
   const [
     connectedDisputableVotingApp,
-    {
-      error: disputableVotingError,
-      loading: connectedDisputableVotingAppLoading,
-    },
+    { error: disputableVotingError, loading: disputableVotingLoading },
   ] = useDisputableVotingHook(disputableVotingApp)
 
   const appsLoading =
     agreementAppLoading ||
-    connectedDisputableVotingAppLoading ||
+    disputableVotingLoading ||
     orgAppsLoading ||
     orgLoading
 

--- a/src/providers/VotesSubscription.js
+++ b/src/providers/VotesSubscription.js
@@ -3,14 +3,12 @@ import PropTypes from 'prop-types'
 import connectVoting from '@aragon/connect-disputable-voting'
 import { createAppHook } from '@aragon/connect-react'
 import { captureErrorWithSentry } from '../sentry'
-import { connector } from '../current-environment'
+import { connectorConfig } from '../current-environment'
 import { useOrgApps } from '../providers/OrgApps'
-
-const { disputableVoting } = connector
 
 const useDisputableVoting = createAppHook(
   connectVoting,
-  disputableVoting.connectorConfig
+  connectorConfig.disputableVoting
 )
 const VotesSubscriptionContext = React.createContext()
 

--- a/src/providers/VotesSubscription.js
+++ b/src/providers/VotesSubscription.js
@@ -1,9 +1,10 @@
 import React, { useContext, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import connectVoting from '@aragon/connect-disputable-voting'
-import { createAppHook, useApp } from '@aragon/connect-react'
+import { createAppHook } from '@aragon/connect-react'
 import { captureErrorWithSentry } from '../sentry'
 import { connector } from '../current-environment'
+import { useOrgApps } from '../providers/OrgApps'
 
 const { disputableVoting } = connector
 
@@ -14,14 +15,11 @@ const useDisputableVoting = createAppHook(
 const VotesSubscriptionContext = React.createContext()
 
 function VotesSubscriptionProvider({ children }) {
-  const [votingApp, votingAppStatus] = useApp(disputableVoting.appName)
-  const [votes, votesStatus] = useDisputableVoting(votingApp, (app) =>
-    app.onVotes()
+  const { disputableVotingApp } = useOrgApps()
+  const [votes, { loading, error }] = useDisputableVoting(
+    disputableVotingApp,
+    (app) => app.onVotes()
   )
-
-  const loading = votingAppStatus.loading || votesStatus.loading
-  const error = votingAppStatus.error || votesStatus.error
-
   if (error) {
     captureErrorWithSentry(error)
     console.error(error)

--- a/src/utils/app-utils.js
+++ b/src/utils/app-utils.js
@@ -1,4 +1,3 @@
-import { addressesEqual } from '../lib/web3-utils'
 import { getIpfsUrlFromUri } from '../lib/ipfs-utils'
 import iconAcl from '../assets/icon-acl.svg'
 import iconKernel from '../assets/icon-kernel.svg'

--- a/src/utils/app-utils.js
+++ b/src/utils/app-utils.js
@@ -39,7 +39,7 @@ export function getAppPresentation(app) {
 
     return {
       humanName: name,
-      iconSrc: iconPath ? getIpfsUrlFromUri(contentUri) + iconPath : null,
+      iconSrc: iconPath ? getIpfsUrlFromUri(contentUri) + iconPath : '',
     }
   }
 

--- a/src/utils/app-utils.js
+++ b/src/utils/app-utils.js
@@ -1,3 +1,4 @@
+import { addressesEqual } from '../lib/web3-utils'
 import { getIpfsUrlFromUri } from '../lib/ipfs-utils'
 import iconAcl from '../assets/icon-acl.svg'
 import iconKernel from '../assets/icon-kernel.svg'
@@ -29,19 +30,17 @@ export const KNOWN_SYSTEM_APPS = new Map([
   ],
 ])
 
-export function getAppPresentation(apps, appAddress) {
-  const { contentUri, manifest, appId } = apps.find(
-    ({ address }) => address === appAddress
-  )
+export function getAppPresentation(app) {
+  const { contentUri, manifest, appId } = app
 
   // Get human readable name and icon from manifest if available
-  if (manifest && manifest.name && manifest.icons) {
+  if (manifest && contentUri) {
     const { name, icons } = manifest
-    const iconPath = icons[0].src
+    const iconPath = icons && icons[0].src
 
     return {
       humanName: name,
-      iconSrc: getIpfsUrlFromUri(contentUri) + iconPath,
+      iconSrc: iconPath ? getIpfsUrlFromUri(contentUri) + iconPath : null,
     }
   }
 


### PR DESCRIPTION
We were calling `describeScript` twice as often as necessary on the list view which was very occasionally throwing request errors. I also added guards against failed requests on `manifest` where previously we were assuming it would always succeed.